### PR TITLE
Bump multer in /cms-backend in the npm_and_yarn group across 1 directory

### DIFF
--- a/cms-backend/package.json
+++ b/cms-backend/package.json
@@ -17,7 +17,7 @@
         "express-validator": "^7.0.1",
         "jsonwebtoken": "^9.0.2",
         "mariadb": "^3.3.3",
-        "multer": "^1.4.5-lts.1",
+        "multer": "^2.0.1",
         "nodemailer": "^7.0.5",
         "sequelize": "^6.35.1"
     }


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update in the /cms-backend directory: [multer](https://github.com/expressjs/multer).


Updates `multer` from 1.4.5-lts.2 to 2.0.1
- [Release notes](https://github.com/expressjs/multer/releases)
- [Changelog](https://github.com/expressjs/multer/blob/main/CHANGELOG.md)
- [Commits](https://github.com/expressjs/multer/compare/v1.4.5-lts.2...v2.0.1)

---
updated-dependencies:
- dependency-name: multer dependency-version: 2.0.1 dependency-type: direct:production dependency-group: npm_and_yarn ...